### PR TITLE
Dockerize Blockchain Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ blockchain_node-*.tar
 *.block
 /latest/
 node_modules/
+
+# Ignore .ssh for Docker builds
+.ssh/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM erlang:alpine
+
+# Install Rebar3
+RUN mkdir -p /buildroot/rebar3/bin
+ADD https://s3.amazonaws.com/rebar3/rebar3 /buildroot/rebar3/bin/rebar3
+RUN chmod a+x /buildroot/rebar3/bin/rebar3
+
+# Setup Environment
+ENV PATH=/buildroot/rebar3/bin:$PATH
+
+# Reset working directory
+WORKDIR /buildroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,29 @@
-FROM erlang:alpine
 
-# Install Rebar3
-RUN mkdir -p /buildroot/rebar3/bin
-ADD https://s3.amazonaws.com/rebar3/rebar3 /buildroot/rebar3/bin/rebar3
-RUN chmod a+x /buildroot/rebar3/bin/rebar3
+#===========
+#Build Stage
+#===========
+FROM elixir:latest as build
+#RUN apk update && apk add --no-cache openssh git make autoconf automake wget yasm gmp libtool cmake clang build-base gcc abuild binutils linux-headers
+COPY --chown=root .ssh/id_rsa /root/.ssh/id_rsa
+RUN ssh-keyscan github.com >> /root/.ssh/known_hosts
+RUN apt-get update && apt-get install -y cmake doxygen
 
-# Setup Environment
-ENV PATH=/buildroot/rebar3/bin:$PATH
 
-# Reset working directory
-WORKDIR /buildroot
+COPY . .
+
+RUN rm -Rf _build \
+    && mix local.rebar --force \
+    && mix local.hex --force \
+    && mix deps.get \
+    && make release
+
+RUN ./cmd genesis onboard
+
+EXPOSE 4001
+ENV REPLACE_OS_VARS=true PORT=4001
+
+# COPY --from=build /export/ .
+
+#USER default
+ENTRYPOINT ["_build/prod/rel/blockchain_node/bin/blockchain_node"]
+CMD ["foreground", ";", "genesis onboard"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ RUN rm -Rf _build \
     && mix deps.get \
     && make release
 
-RUN ./cmd genesis onboard
-
 EXPOSE 4001
 ENV REPLACE_OS_VARS=true PORT=4001
 
@@ -26,4 +24,4 @@ ENV REPLACE_OS_VARS=true PORT=4001
 
 #USER default
 ENTRYPOINT ["_build/prod/rel/blockchain_node/bin/blockchain_node"]
-CMD ["foreground", ";", "genesis onboard"]
+CMD ["foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,23 @@ RUN rm -Rf _build \
     && mix deps.get \
     && make release
 
-# RUN ./cmd start
-# RUN ./cmd genesis onboard
-# RUN ./cmd stop
+#Extract Release archive to /rel for copying in next stage
+RUN APP_NAME="blockchain_node"  \
+    && RELEASE_DIR=`ls -d _build/prod/rel/$APP_NAME/releases/*/` \
+    && mkdir /export \
+    && tar -xf "$RELEASE_DIR/$APP_NAME.tar.gz" -C /export
+
+
+#================
+#Deployment Stage
+#================
+FROM elixir:latest
+
+COPY --from=build /export/ .
+COPY --from=build /cmd .
 
 EXPOSE 4001
 ENV REPLACE_OS_VARS=true PORT=4001
 
-ENTRYPOINT ["_build/prod/rel/blockchain_node/bin/blockchain_node"]
+ENTRYPOINT ["/bin/blockchain_node"]
 CMD ["foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,28 @@
 #Build Stage
 #===========
 FROM elixir:latest as build
-#RUN apk update && apk add --no-cache openssh git make autoconf automake wget yasm gmp libtool cmake clang build-base gcc abuild binutils linux-headers
-COPY --chown=root .ssh/id_rsa /root/.ssh/id_rsa
-RUN ssh-keyscan github.com >> /root/.ssh/known_hosts
-RUN apt-get update && apt-get install -y cmake doxygen
+RUN apt-get update && apt-get install -y cmake doxygen 
 
+COPY --chown=root .ssh/id_rsa /root/.ssh/id_rsa
+RUN chmod 600 /root/.ssh/id_rsa
+RUN ssh-keyscan github.com >> /root/.ssh/known_hosts
+RUN echo "StrictHostKeyChecking no " >> /root/.ssh/config
 
 COPY . .
 
 RUN rm -Rf _build \
+    && rm -Rf deps \
     && mix local.rebar --force \
     && mix local.hex --force \
     && mix deps.get \
     && make release
 
+# RUN ./cmd start
+# RUN ./cmd genesis onboard
+# RUN ./cmd stop
+
 EXPOSE 4001
 ENV REPLACE_OS_VARS=true PORT=4001
 
-# COPY --from=build /export/ .
-
-#USER default
 ENTRYPOINT ["_build/prod/rel/blockchain_node/bin/blockchain_node"]
 CMD ["foreground"]

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,13 @@ docker-build:
 	docker create -p 4001:4001 --name=blockchain-node blockchain-node	
 
 docker-start:
-	docker start  blockchain-node
+	docker start blockchain-node
 
 docker-stop:
 	docker stop blockchain-node
 
+docker-genesis-onboard:
+	docker exec -it blockchain-node sh -c "/_build/prod/rel/blockchain_node/bin/blockchain_node genesis onboard"
+
+docker-shell:
+	docker exec -it blockchain-node bash

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,14 @@ deployable: release
 	@mkdir latest
 	@cd _build/prod/rel && tar -czf blockchain_node-$(NODE_OS).tgz blockchain_node
 	@mv _build/prod/rel/blockchain_node-$(NODE_OS).tgz latest/
+
+docker-build:
+	docker build -t blockchain-node .
+	docker create -p 4001:4001 --name=blockchain-node blockchain-node	
+
+docker-start:
+	docker start  blockchain-node
+
+docker-stop:
+	docker stop blockchain-node
+

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ deployable: release
 
 docker-build:
 	docker build -t blockchain-node .
-	docker create -p 4001:4001 --name=blockchain-node blockchain-node	
+	docker create -p 4001:4001 -v /root/.helium --name=blockchain-node blockchain-node	
 
 docker-start:
 	docker start blockchain-node
@@ -39,7 +39,7 @@ docker-stop:
 	docker stop blockchain-node
 
 docker-genesis-onboard:
-	docker exec -it blockchain-node sh -c "/_build/prod/rel/blockchain_node/bin/blockchain_node genesis onboard"
+	docker exec -it blockchain-node sh -c "/bin/blockchain_node genesis onboard"
 
 docker-shell:
-	docker exec -it blockchain-node bash
+	docker exec -it blockchain-node sh

--- a/README.md
+++ b/README.md
@@ -156,3 +156,14 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/blockchain_node](https://hexdocs.pm/blockchain_node).
 
+## Using Docker
+
+You can build and run the node in a docker container using the following instructions. *IMPORTANT*: you will need to copy a private ssh key that has access to helium's private github repos to `.ssh/id_rsa`.  The `.ssh/` directory is in `.gitignore` so the key will remain local to each user.
+
+To Build the container, use: `make docker-build`.
+
+To start the container, use: `make docker-start`. Note that this command will fail if you haven't built the container first.  This command will use the existing container each time it is run.  If the repository is updated, you must re-run `make docker-build` first.
+
+To stop the container, use; `make docker-stop`.
+
+

--- a/cmd_docker
+++ b/cmd_docker
@@ -19,4 +19,4 @@ while getopts e: o; do
 done
 shift "$((OPTIND - 1))"
 
-docker exec -it blockchain-node sh /cmd $@
+docker exec -it blockchain-node sh /bin/blockchain_node $@

--- a/cmd_docker
+++ b/cmd_docker
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+PROGNAME=$0
+
+usage() {
+  cat << EOF >&2
+Usage: $PROGNAME [-e <env>]
+
+-e <env>: ...
+EOF
+  exit 1
+}
+
+env=prod
+while getopts e: o; do
+  case $o in
+    (e) env=$OPTARG;;
+    (*) usage
+  esac
+done
+shift "$((OPTIND - 1))"
+
+docker exec -it blockchain-node sh /cmd $@


### PR DESCRIPTION
This pull requests allows the ability to run the node in a docker container.
- Adds instructions to `README`
- Adds targets: `make docker-build`, `make docker-start`, `make docker-stop` to `makefile`
- Adds Dockerfile

TODO: add genesis block automation.  For now you can start the node and then override the `CMD` entry point and pass `genesis onboard`.