### PR TITLE
Update Makefile with port 44158 for docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ docker-clean: docker-stop
 docker-start:
 	mkdir -p $(HOME)/node_data
 	docker run -d --init \
-	--publish 2154:2154/tcp \
+	--publish 44158:44158/tcp \
 	--publish 4467:4467 \
 	--name node \
 	--mount type=bind,source=$(HOME)/node_data,target=/var/data \


### PR DESCRIPTION
Currently with this docker setup node runs on 44158 but 2154 is published, resulting in a relayed node.

