### PR TITLE
Load genesis txns

### DIFF
--- a/src/bn_txns.erl
+++ b/src/bn_txns.erl
@@ -54,11 +54,11 @@ follower_height(#state{db = DB, default = DefaultCF}) ->
         {error, _} = Error -> ?jsonrpc_error(Error)
     end.
 
-load_chain(_Chain, State = #state{}) ->
+load_chain(Chain, State = #state{}) ->
     maybe_load_genesis(State).
 
-maybe_load_genesis(State = #state{}) ->
-    case blockchain:get_block(1, blockchain_worker:blockchain()) of
+maybe_load_genesis(Chain, State = #state{}) ->
+    case blockchain:get_block(1, Chain) of
         {ok, Block} ->
             Hash = blockchain_txn:hash(lists:last(blockchain_block:transactions(Block))),
             case get_transaction(Hash, State) of

--- a/src/bn_txns.erl
+++ b/src/bn_txns.erl
@@ -54,18 +54,18 @@ follower_height(#state{db = DB, default = DefaultCF}) ->
         {error, _} = Error -> ?jsonrpc_error(Error)
     end.
 
-load_chain(_Chain, State0 = #state{}) ->
-    maybe_load_genesis(State0).
+load_chain(_Chain, State = #state{}) ->
+    maybe_load_genesis(State).
 
-maybe_load_genesis(State0 = #state{}) ->
+maybe_load_genesis(State = #state{}) ->
     case blockchain:get_block(1, blockchain_worker:blockchain()) of
         {ok, Block} ->
             Hash = blockchain_txn:hash(lists:last(blockchain_block:transactions(Block))),
-            case get_transaction(Hash, State0) of
+            case get_transaction(Hash, State) of
                 {ok, _} -> % already loaded
-                    {ok, State0};
+                    {ok, State};
                 _ -> % attempt to load
-                    load_block([], Block, [], [], State0)
+                    load_block([], Block, [], [], State)
             end;
         Error ->
             Error

--- a/src/bn_txns.erl
+++ b/src/bn_txns.erl
@@ -55,7 +55,7 @@ follower_height(#state{db = DB, default = DefaultCF}) ->
     end.
 
 load_chain(Chain, State = #state{}) ->
-    maybe_load_genesis(State).
+    maybe_load_genesis(Chain, State).
 
 maybe_load_genesis(Chain, State = #state{}) ->
     case blockchain:get_block(1, Chain) of


### PR DESCRIPTION
This PR is to load the genesis block txns into the db so that blockchain-node can query them. Currently the `transaction_get` for txn hash `RNaJpIU3K5NqUiQuDvgdTMQAdG9UQ0RtwkySWq-rLVE` is not available in blockchain-node. 

This code path currently triggers every time a txn hash isn't found when using `transaction_get`. It wasn't clear if there was another place to modify the code so that the genesis block is loaded on init, or if that might be a blockchain-core change. Open to suggestions to modify.

Required for proper Rosetta API configuration here: https://github.com/helium/rosetta-helium/pull/22