### PR TITLE
Disable extra processing logic

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -38,8 +38,8 @@
                 162, 59, 180, 164, 195, 18, 72, 169, 72, 153, 183, 114, 159, 34>>},
 
         {listen_addresses, ["/ip4/0.0.0.0/tcp/44158"]},
-        {store_implicit_burns, true},
-        {store_htlc_receipts, true},
+        {store_implicit_burns, false},
+        {store_htlc_receipts, false},
         {key, undefined},
         {base_dir, "data"},
         {autoload, false},


### PR DESCRIPTION
This reduces busy work that is not used by most node runners