### PR TITLE
Bump nofile/nproc ulimit to 200k

### DIFF
--- a/deb/blockchain-node.service
+++ b/deb/blockchain-node.service
@@ -11,8 +11,8 @@ PIDFile=/var/data/blockchain_node/blockchain_node.pid
 Environment=HOME="/var/data/blockchain_node"
 Environment=RUNNER_LOG_DIR="/var/data/log/blockchain_node"
 Environment=ERL_CRASH_DUMP="/var/data/log/blockchain_node"
-LimitNOFILE=64000
-LimitNPROC=64000
+LimitNOFILE=200000
+LimitNPROC=200000
 Restart=always
 
 [Install]


### PR DESCRIPTION
Problem to solve: Rocks needs file descriptors in excess of 64k during start up sometimes (when loading snapshots especially)