### PR TITLE
Store historic balances (and other commits)

### DIFF
--- a/config/docker_rosetta.config
+++ b/config/docker_rosetta.config
@@ -17,6 +17,8 @@
   [
    {base_dir, "/data"},
    {store_implicit_burns, true},
-   {store_htlc_receipts, true}
+   {store_htlc_receipts, true},
+   {snap_source_base_url, "https://snapshots.helium.wtf/mainnet"},
+   {fetch_latest_from_snap_source, false}
   ]}
 ].

--- a/config/docker_rosetta_testnet.config
+++ b/config/docker_rosetta_testnet.config
@@ -23,5 +23,7 @@
    {quick_sync_mode, assumed_valid},
    {store_implicit_burns, true},
    {store_htlc_receipts, true}
+   {snap_source_base_url, "https://snapshots.helium.wtf/testnet"},
+   {fetch_latest_from_snap_source, false}
   ]}
 ].

--- a/config/sys.config
+++ b/config/sys.config
@@ -38,8 +38,17 @@
                 162, 59, 180, 164, 195, 18, 72, 169, 72, 153, 183, 114, 159, 34>>},
 
         {listen_addresses, ["/ip4/0.0.0.0/tcp/44158"]},
-        {store_implicit_burns, false},
         {store_htlc_receipts, false},
+        {store_implicit_burns, false},
+        {store_historic_balances, false},
+        {commit_hook_callbacks, [
+            {entries, undefined, fun bn_balances:incremental_commit_hook/1,
+                fun bn_balances:end_commit_hook/2},
+            {dc_entries, undefined, fun bn_balances:incremental_commit_hook/1,
+                fun bn_balances:end_commit_hook/2},
+            {securities, undefined, fun bn_balances:incremental_commit_hook/1,
+                fun bn_balances:end_commit_hook/2}
+        ]},
         {key, undefined},
         {base_dir, "data"},
         {autoload, false},

--- a/rebar.config
+++ b/rebar.config
@@ -32,7 +32,7 @@
     {elli, "3.2.0"},
     {jsonrpc2, {git, "https://github.com/zuiderkwast/jsonrpc2-erlang.git", {branch, "master"}}},
     {clique, {git, "https://github.com/helium/clique.git", {branch, "develop"}}},
-    {blockchain, {git, "https://github.com/helium/blockchain-core.git", {tag, "2021.10.21.0"}}}
+    {blockchain, {git, "https://github.com/helium/blockchain-core.git", {tag, "2021.11.04.2"}}}
 ]}.
 
 {xref_checks, [

--- a/src/bn_accounts.erl
+++ b/src/bn_accounts.erl
@@ -24,75 +24,101 @@ handle_rpc(<<"account_get">>, {Param}) ->
                     {ok, OldLedger} ->
                         {V, OldLedger};
                     {error, height_too_old} ->
-                        {V,
-                            ?jsonrpc_error(
-                                {error, "height ~p is too old to get historic account data", [V]}
-                            )};
+                        case application:get_env(blockchain, store_historic_balances, false) of
+                            true ->
+                                {V, {error, height_too_old}};
+                            false ->
+                                {V, ?jsonrpc_error(
+                                    {error, "height ~p is too old to get historic account data", [V]}
+                                )}
+                        end;
                     {error, _} = Error ->
                         {V, ?jsonrpc_error(Error)}
                 end
         end,
     Address = ?jsonrpc_b58_to_bin(<<"address">>, Param),
-    GetBalance = fun() ->
-        case blockchain_ledger_v1:find_entry(Address, Ledger) of
-            {ok, Entry} ->
+    case Ledger of
+        {error, height_too_old} ->
+            case bn_balances:get_historic_entry(Address, Height) of
+                {ok, {EntryBin, DCEntryBin, SecurityEntryBin}} ->
+                    Entry = blockchain_ledger_entry_v1:deserialize(EntryBin),
+                    DCEntry = blockchain_ledger_data_credits_entry_v1:deserialize(DCEntryBin),
+                    SecurityEntry = blockchain_ledger_security_entry_v1:deserialize(SecurityEntryBin),
+                    #{
+                        address => ?BIN_TO_B58(Address),
+                        block => Height,
+                        balance => blockchain_ledger_entry_v1:balance(Entry),
+                        nonce => blockchain_ledger_entry_v1:nonce(Entry),
+                        sec_balance => blockchain_ledger_security_entry_v1:balance(SecurityEntry),
+                        sec_nonce => blockchain_ledger_security_entry_v1:nonce(SecurityEntry),
+                        dc_balance => blockchain_ledger_data_credits_entry_v1:balance(DCEntry),
+                        dc_nonce => blockchain_ledger_data_credits_entry_v1:nonce(DCEntry)
+                    };
+                {error, _} ->
+                    ?jsonrpc_error({error, "unable to retrieve account details for ~p at height ~p", [?BIN_TO_B58(Address), Height]})
+            end;
+        _ ->
+            GetBalance = fun() ->
+                case blockchain_ledger_v1:find_entry(Address, Ledger) of
+                    {ok, Entry} ->
+                        #{
+                            balance => blockchain_ledger_entry_v1:balance(Entry),
+                            nonce => blockchain_ledger_entry_v1:nonce(Entry),
+                            speculative_nonce => get_speculative_nonce(Address, balance, Ledger)
+                        };
+                    _ ->
+                        #{
+                            balance => 0,
+                            nonce => 0,
+                            speculative_nonce => 0
+                        }
+                end
+            end,
+            GetSecurities = fun() ->
+                case blockchain_ledger_v1:find_security_entry(Address, Ledger) of
+                    {ok, Entry} ->
+                        #{
+                            sec_balance => blockchain_ledger_security_entry_v1:balance(Entry),
+                            sec_nonce => blockchain_ledger_security_entry_v1:nonce(Entry),
+                            sec_speculative_nonce => get_speculative_nonce(
+                                Address,
+                                security,
+                                Ledger
+                            )
+                        };
+                    _ ->
+                        #{
+                            sec_balance => 0,
+                            sec_nonce => 0,
+                            sec_speculative_nonce => 0
+                        }
+                end
+            end,
+            GetDCs = fun() ->
+                case blockchain_ledger_v1:find_dc_entry(Address, Ledger) of
+                    {ok, Entry} ->
+                        #{
+                            dc_balance => blockchain_ledger_data_credits_entry_v1:balance(Entry),
+                            dc_nonce => blockchain_ledger_data_credits_entry_v1:nonce(Entry)
+                        };
+                    _ ->
+                        #{
+                            dc_balance => 0,
+                            dc_nonce => 0
+                        }
+                end
+            end,
+            lists:foldl(
+                fun(Fun, Map) ->
+                    maps:merge(Map, Fun())
+                end,
                 #{
-                    balance => blockchain_ledger_entry_v1:balance(Entry),
-                    nonce => blockchain_ledger_entry_v1:nonce(Entry),
-                    speculative_nonce => get_speculative_nonce(Address, balance, Ledger)
-                };
-            _ ->
-                #{
-                    balance => 0,
-                    nonce => 0,
-                    speculative_nonce => 0
-                }
-        end
-    end,
-    GetSecurities = fun() ->
-        case blockchain_ledger_v1:find_security_entry(Address, Ledger) of
-            {ok, Entry} ->
-                #{
-                    sec_balance => blockchain_ledger_security_entry_v1:balance(Entry),
-                    sec_nonce => blockchain_ledger_security_entry_v1:nonce(Entry),
-                    sec_speculative_nonce => get_speculative_nonce(
-                        Address,
-                        security,
-                        Ledger
-                    )
-                };
-            _ ->
-                #{
-                    sec_balance => 0,
-                    sec_nonce => 0,
-                    sec_speculative_nonce => 0
-                }
-        end
-    end,
-    GetDCs = fun() ->
-        case blockchain_ledger_v1:find_dc_entry(Address, Ledger) of
-            {ok, Entry} ->
-                #{
-                    dc_balance => blockchain_ledger_data_credits_entry_v1:balance(Entry),
-                    dc_nonce => blockchain_ledger_data_credits_entry_v1:nonce(Entry)
-                };
-            _ ->
-                #{
-                    dc_balance => 0,
-                    dc_nonce => 0
-                }
-        end
-    end,
-    lists:foldl(
-        fun(Fun, Map) ->
-            maps:merge(Map, Fun())
-        end,
-        #{
-            address => ?BIN_TO_B58(Address),
-            block => Height
-        },
-        [GetBalance, GetSecurities, GetDCs]
-    );
+                    address => ?BIN_TO_B58(Address),
+                    block => Height
+                },
+                [GetBalance, GetSecurities, GetDCs]
+            )
+    end;
 handle_rpc(_, _) ->
     ?jsonrpc_error(method_not_found).
 

--- a/src/bn_balances.erl
+++ b/src/bn_balances.erl
@@ -1,0 +1,243 @@
+-module(bn_balances).
+
+-include("bn_jsonrpc.hrl").
+%% blockchain_follower
+-export([
+    requires_sync/0,
+    requires_ledger/0,
+    init/1,
+    follower_height/1,
+    load_chain/2,
+    load_block/5,
+    terminate/2
+]).
+
+% api
+-export([get_historic_entry/2]).
+% hooks
+-export([incremental_commit_hook/1, end_commit_hook/2]).
+
+-define(DB_FILE, "balances.db").
+-define(SERVER, ?MODULE).
+
+-record(state, {
+    dir :: file:filename_all(),
+    db :: rocksdb:db_handle(),
+    default :: rocksdb:cf_handle(),
+    entries :: rocksdb:cf_handle()
+}).
+
+%%
+%% Blockchain follower
+%%
+
+requires_ledger() -> false.
+
+requires_sync() -> false.
+
+init(Args) ->
+    Dir = filename:join(proplists:get_value(base_dir, Args, "data"), ?DB_FILE),
+    case load_db(Dir) of
+        {ok, State} ->
+            ets:new(?MODULE, [public, named_table]),
+            persistent_term:put(?MODULE, State),
+            {ok, State};
+        Error ->
+            Error
+    end.
+
+follower_height(#state{db = DB, default = DefaultCF}) ->
+    case bn_db:get_follower_height(DB, DefaultCF) of
+        {ok, Height} -> Height;
+        {error, _} = Error -> ?jsonrpc_error(Error)
+    end.
+
+load_chain(_Chain, State = #state{}) ->
+    {ok, State}.
+
+load_block(_Hash, Block, _Sync, Ledger, State = #state{
+    db=DB, 
+    default=DefaultCF, 
+    entries=EntriesCF
+}) ->
+    case Ledger of
+        undefined ->
+            Height = blockchain_block:height(Block),
+            bn_db:put_follower_height(DB, DefaultCF, Height),
+            {ok, State};
+        _ ->
+            {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
+            case rocksdb:get(DB, DefaultCF, <<"loaded_initial_balances">>, []) of
+                not_found ->
+                    {ok, Batch} = rocksdb:batch(),
+                    lager:info("Loading initial balances at height ~p", [Height]),
+                    EntrySnapshotList = blockchain_ledger_v1:snapshot_raw_accounts(Ledger),
+                    DCSnapshotList = blockchain_ledger_v1:snapshot_raw_dc_accounts(Ledger),
+                    SecuritySnapshotList = blockchain_ledger_v1:snapshot_raw_security_accounts(Ledger),
+                    ZeroEntry = blockchain_ledger_entry_v1:new(0, 0),
+                    ZeroEntryBin = blockchain_ledger_entry_v1:serialize(ZeroEntry),
+                    DCZeroEntry = blockchain_ledger_data_credits_entry_v1:new(0, 0),
+                    DCZeroEntryBin = blockchain_ledger_data_credits_entry_v1:serialize(DCZeroEntry),
+                    SecurityZeroEntry = blockchain_ledger_security_entry_v1:new(0, 0),
+                    SecurityZeroEntryBin = blockchain_ledger_security_entry_v1:serialize(SecurityZeroEntry),
+                    lists:foreach(
+                        fun({Entries, Type}) ->
+                            lists:foldl(
+                                fun({AddressBin, EntryBin}, Acc) ->
+                                    HeightBin = integer_to_binary(Height),
+                                    HeightEntryKeyBin = <<AddressBin/binary, HeightBin/binary>>,
+                                    HeightEntryValueBin = case Type of
+                                        "entries" ->
+                                            erlang:term_to_binary({EntryBin, DCZeroEntryBin, SecurityZeroEntryBin});
+                                        "dcs" ->
+                                            case rocksdb:get(DB, EntriesCF, HeightEntryKeyBin, []) of
+                                                not_found ->
+                                                    erlang:term_to_binary({ZeroEntryBin, EntryBin, SecurityZeroEntryBin});
+                                                {ok, B} ->
+                                                    {Entry, _, _} = erlang:binary_to_term(B),
+                                                    erlang:term_to_binary({Entry, EntryBin, SecurityZeroEntryBin})
+                                            end;
+                                        "securities" ->
+                                            case rocksdb:get(DB, EntriesCF, HeightEntryKeyBin, []) of
+                                                not_found ->
+                                                    erlang:term_to_binary({ZeroEntryBin, DCZeroEntryBin, EntryBin});
+                                                {ok, B} ->
+                                                    {Entry, DCEntry, _} = erlang:binary_to_term(B),
+                                                    erlang:term_to_binary({Entry, DCEntry, EntryBin})
+                                            end
+                                    end,
+                                    rocksdb:put(DB, EntriesCF, HeightEntryKeyBin, HeightEntryValueBin, []),
+                                    Acc
+                                end,
+                                [],
+                                Entries
+                            )
+                        end,
+                        [
+                            {EntrySnapshotList, "entries"},
+                            {DCSnapshotList, "dcs"},
+                            {SecuritySnapshotList, "securities"}
+                        ]
+                    ),
+                    lager:info("Finished saving initial balances"),
+                    rocksdb:batch_put(Batch, <<"loaded_initial_balances">>, <<"true">>),
+                    bn_db:batch_put_follower_height(Batch, DefaultCF, Height),
+                    rocksdb:write_batch(DB, Batch, []);
+                {ok, <<"true">>} ->
+                    {ok, Batch} = rocksdb:batch(),
+                    ets:foldl(
+                        fun ({Key}, Acc) ->
+                            batch_update_entry(Key, Ledger, Batch, Height),
+                            Acc
+                        end,
+                        [],
+                        ?MODULE
+                    ),
+                    bn_db:batch_put_follower_height(Batch, DefaultCF, Height),
+                    rocksdb:write_batch(DB, Batch, []),
+                    ets:delete_all_objects(?MODULE)
+            end,
+            {ok, State}
+    end.
+
+terminate(_Reason, #state{db = DB}) ->
+    rocksdb:close(DB).
+
+%%
+%% Hooks
+%%
+
+incremental_commit_hook(_Changes) -> 
+    ok.
+
+end_commit_hook(_CF, Changes) ->
+    Keys = lists:filtermap(
+        fun
+            ({put, Key}) -> {true, {Key}};
+            (_) -> false
+        end,
+        Changes
+    ),
+    ets:insert(?MODULE, Keys).
+
+%%
+%% Internal
+%%
+
+get_state() ->
+    bn_db:get_state(?MODULE).
+
+-spec load_db(file:filename_all()) -> {ok, #state{}} | {error, any()}.
+load_db(Dir) ->
+    case bn_db:open_db(Dir, ["default", "entries"], [{prefix_transform, {fixed_prefix_transform, 33}}]) of
+        {error, _Reason} = Error ->
+            Error;
+        {ok, DB, [DefaultCF, EntriesCF]} ->
+            State = #state{
+                dir = Dir,
+                db = DB,
+                default = DefaultCF,
+                entries = EntriesCF
+            },
+            compact_db(State),
+            {ok, State}
+    end.
+
+batch_update_entry(Key, Ledger, Batch, Height) ->
+    {ok, #state{entries=EntriesCF}} = get_state(),
+    HeightBin = integer_to_binary(Height),
+    HeightEntryKeyBin = <<Key/binary, HeightBin/binary>>,
+    EntryBin = case blockchain_ledger_v1:find_entry(Key, Ledger) of
+        {ok, Entry} ->
+            blockchain_ledger_entry_v1:serialize(Entry);
+        {error,address_entry_not_found} ->
+            ZeroEntry = blockchain_ledger_entry_v1:new(0, 0),
+            blockchain_ledger_entry_v1:serialize(ZeroEntry)
+    end,
+    DCBin = case blockchain_ledger_v1:find_dc_entry(Key, Ledger) of
+        {ok, DCEntry} ->
+            blockchain_ledger_entry_v1:serialize(DCEntry);
+        {error,dc_entry_not_found} ->
+            DCZeroEntry = blockchain_ledger_data_credits_entry_v1:new(0, 0),
+            blockchain_ledger_data_credits_entry_v1:serialize(DCZeroEntry)
+    end,
+    SecurityBin = case blockchain_ledger_v1:find_security_entry(Key, Ledger) of
+        {ok, SecurityEntry} ->
+            blockchain_ledger_entry_v1:serialize(SecurityEntry);
+        {error,not_found} ->
+            SecurityZeroEntry = blockchain_ledger_security_entry_v1:new(0, 0),
+            blockchain_ledger_security_entry_v1:serialize(SecurityZeroEntry)
+    end,
+    rocksdb:batch_put(Batch, EntriesCF, HeightEntryKeyBin, erlang:term_to_binary({EntryBin, DCBin, SecurityBin})).
+
+-spec get_historic_entry(Key :: binary(), Height :: pos_integer()) ->
+    {ok, map()} | {error, term()}.
+get_historic_entry(Key, Height) ->
+    {ok, #state{
+        db=DB,
+        entries=EntriesCF
+    }} = get_state(),
+    ZeroHeightBin = integer_to_binary(0),
+    {ok, BalanceIterator} = rocksdb:iterator(DB, EntriesCF, [{iterate_lower_bound, <<Key/binary, ZeroHeightBin/binary>>}]),
+    % Increment requested height in order to account for the
+    % possibility that the requested height is the entry height
+    ReqHeightBin = integer_to_binary(Height + 1),
+    rocksdb:iterator_move(BalanceIterator, {seek, <<Key/binary, ReqHeightBin/binary>>}),
+    case rocksdb:iterator_move(BalanceIterator, prev) of
+        {ok, _, EntryBin} ->
+            {ok, erlang:binary_to_term(EntryBin)};
+        {ok, _} ->
+            {error, invalid_entry};
+        {error, Error} ->
+            {error, Error}
+    end.
+
+
+compact_db(#state{
+    db = DB,
+    default = Default,
+    entries=EntriesCF
+}) ->
+    rocksdb:compact_range(DB, Default, undefined, undefined, []),
+    rocksdb:compact_range(DB, EntriesCF, undefined, undefined, []),
+    ok.

--- a/src/bn_sup.erl
+++ b/src/bn_sup.erl
@@ -92,6 +92,9 @@ init([]) ->
             ?WORKER(oracle_price_follower, blockchain_follower, [
                 [{follower_module, {bn_oracle_price, [{base_dir, BaseDir}]}}]
             ]),
+            ?WORKER(balances_follower, blockchain_follower, [
+                [{follower_module, {bn_balances, [{base_dir, BaseDir}]}}]
+            ]),
             ?WORKER(bn_wallets, [[{base_dir, BaseDir}]]),
             ?WORKER(elli, [[{callback, bn_jsonrpc_handler}, {port, NodePort}]])
         ]}}.

--- a/src/bn_txns.erl
+++ b/src/bn_txns.erl
@@ -228,3 +228,4 @@ compact_db(#state{db = DB, default = Default, transactions = TransactionsCF, jso
     rocksdb:compact_range(DB, TransactionsCF, undefined, undefined, []),
     rocksdb:compact_range(DB, JsonCF, undefined, undefined, []),
     ok.
+ 


### PR DESCRIPTION
Proposed instead of #59 #73

Add balance saving to blockchain txn follower + new config var

Add get_historic_balance helper and jsonrpc handler logic

Rework case statements / config variables

Track balance on current ledger height, not block load

Fix get_historic_balance fun

Revert bn_txn.erl

Comment notes

Refactor giant case statement

Add bn_balances.erl follower

Implement hooks

Update bn_balances to use commit hooks

Comments / Bug fixes

Revert main config to be false

Set default historic balance storage to true (for now) include more commit hooks

Refactor to use blockchain follower / entry size vs height list method for back tracking

Update match to any ok

Initial refactor for combined entry storage

Add CF options on DB open

Refactor bn_balances to use prefix seek

Update accounts to use new get_historic_entry

Bump core to 2021.11.04.2