### PR TITLE
Fix rosetta configs

### DIFF
--- a/config/docker_rosetta.config
+++ b/config/docker_rosetta.config
@@ -18,6 +18,7 @@
    {base_dir, "/data"},
    {store_implicit_burns, true},
    {store_htlc_receipts, true},
+   {store_historic_balances, true},
    {snap_source_base_url, "https://snapshots.helium.wtf/mainnet"},
    {fetch_latest_from_snap_source, false}
   ]}

--- a/config/docker_rosetta_testnet.config
+++ b/config/docker_rosetta_testnet.config
@@ -22,7 +22,8 @@
    {honor_quick_sync, false},
    {quick_sync_mode, assumed_valid},
    {store_implicit_burns, true},
-   {store_htlc_receipts, true}
+   {store_htlc_receipts, true},
+   {store_historic_balances, true},
    {snap_source_base_url, "https://snapshots.helium.wtf/testnet"},
    {fetch_latest_from_snap_source, false}
   ]}


### PR DESCRIPTION
Forgot to add `store_historic_balance` to config for rosetta + typo fix