### PR TITLE
snap_source_base_url for sys.config

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -27,9 +27,10 @@
     ]},
     {blockchain, [
         {s3_base_url, "https://snapshots.helium.wtf/mainnet"},
+        {snap_source_base_url, "https://snapshots.helium.wtf/mainnet"},
+        {fetch_latest_from_snap_source, false},
         {block_sync_batch_size, 10},
         {block_sync_batch_limit, 100},
-
         {honor_quick_sync, true},
         {quick_sync_mode, blessed_snapshot},
         {blessed_snapshot_block_height, 1042561},


### PR DESCRIPTION
Was getting an error while running node saying `snap_source_base_url` was missing. Adding it to the base config along with `{fetch_latest_from_snap_source, false}` to match docker configs. Let me know if this should be changed.