### PR TITLE
bump core and blessed snapshot

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -33,10 +33,10 @@
         {block_sync_batch_limit, 100},
         {honor_quick_sync, true},
         {quick_sync_mode, blessed_snapshot},
-        {blessed_snapshot_block_height, 1103041},
+        {blessed_snapshot_block_height, 1105607},
         {blessed_snapshot_block_hash,
-            <<49, 248, 61, 121, 169, 91, 43, 168, 98, 219, 66, 79, 43, 27, 241, 89, 31, 67, 134, 35,
-                138, 150, 24, 114, 190, 227, 210, 159, 122, 27, 124, 109>>},
+            <<157, 228, 93, 57, 144, 90, 175, 17, 8, 235, 210, 122, 254, 49, 6, 248, 214, 82, 93,
+                165, 54, 155, 121, 87, 194, 238, 120, 191, 58, 110, 251, 143>>},
 
         {listen_addresses, ["/ip4/0.0.0.0/tcp/44158"]},
         {store_json, false},

--- a/rebar.config
+++ b/rebar.config
@@ -32,7 +32,7 @@
     {elli, "3.2.0"},
     {jsonrpc2, {git, "https://github.com/zuiderkwast/jsonrpc2-erlang.git", {branch, "master"}}},
     {clique, {git, "https://github.com/helium/clique.git", {branch, "develop"}}},
-    {blockchain, {git, "https://github.com/helium/blockchain-core.git", {tag, "2021.11.18.0"}}}
+    {blockchain, {git, "https://github.com/helium/blockchain-core.git", {tag, "2021.11.21.1"}}}
 ]}.
 
 {xref_checks, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -5,7 +5,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},0},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"8a3b7eab5bc99b2b8bfdb66f484a107424157d92"}},
+       {ref,"2aaabe2afd92ffeb789572957a8c6f33479aeb17"}},
   0},
  {<<"chatterbox">>,
   {git,"https://github.com/andymck/chatterbox",


### PR DESCRIPTION
This upgrades core to 2021.11.21.1 to work add some more critical performance improvements under heavy transaction load