### PR TITLE
Pull genesis blocks from S3 for docker images

### DIFF
--- a/.buildkite/Dockerfile-ubuntu
+++ b/.buildkite/Dockerfile-ubuntu
@@ -5,6 +5,7 @@ FROM ${BUILDER_IMAGE} as builder
 
 ARG VERSION
 ARG BUILD_TARGET=docker_rosetta
+ARG GENESIS_BLOCK_FILE=genesis.mainnet
 
 RUN set -xe \
 	    && apt update \
@@ -34,7 +35,8 @@ ADD . /usr/src/node/
 
 RUN ./rebar3 as ${BUILD_TARGET} tar -v ${VERSION} -n blockchain_node
 
-RUN mkdir -p /opt/docker \
+RUN mkdir -p /opt/docker/update \
+	&& wget -O /opt/docker/update/genesis https://snapshots.helium.wtf/${GENESIS_BLOCK_FILE} \
 	&& tar -zxvf _build/${BUILD_TARGET}/rel/*/*.tar.gz -C /opt/docker
 
 FROM ${RUNNER_IMAGE} as runner

--- a/.buildkite/scripts/make_docker.sh
+++ b/.buildkite/scripts/make_docker.sh
@@ -26,7 +26,7 @@ case "$BUILD_TARGET" in
         ;;
     "docker_rosetta_testnet")
         echo "Building rosetta testnet docker"
-        DOCKER_BUILD_ARGS="--build-arg BUILDER_IMAGE=$UBUNTU_BUILDER --build-arg RUNNER_IMAGE=$UBUNTU_RUNNER $DOCKER_BUILD_ARGS"
+        DOCKER_BUILD_ARGS="--build-arg GENESIS_BLOCK_FILE=genesis.testnet --build-arg BUILDER_IMAGE=$UBUNTU_BUILDER --build-arg RUNNER_IMAGE=$UBUNTU_RUNNER $DOCKER_BUILD_ARGS"
         DOCKER_NAME="blockchain-node-testnet-ubuntu18-$VERSION"
         DOCKERFILE=".buildkite/Dockerfile-ubuntu"
         ;;

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: compile rel cover test typecheck doc ci start stop reset
 
 REBAR=./rebar3
-SHORTSHA=`git rev-parse --short HEAD`
-PKG_NAME_VER=${SHORTSHA}
+ALPINE_IMAGE=erlang:23.3.4.9-alpine
+DOCKERFILE_VERSION=`git describe --abbrev=0`
 
 OS_NAME=$(shell uname -s)
 PROFILE ?= dev
@@ -52,7 +52,11 @@ console:
 	./_build/$(PROFILE)/rel/blockchain_node/bin/blockchain_node remote_console
 
 docker-build:
-	docker build -t helium/node .
+	docker build \
+		--build-arg VERSION=$(DOCKERFILE_VERSION) \
+		--build-arg BUILDER_IMAGE=$(ALPINE_IMAGE) \
+		--build-arg RUNNER_IMAGE=$(ALPINE_IMAGE) \
+		-t helium/node .
 
 docker-clean: docker-stop
 	docker rm node

--- a/rebar.config
+++ b/rebar.config
@@ -132,10 +132,8 @@
         {relx, [
             {sys_config, "./config/docker_rosetta_testnet.config"},
             {dev_mode, false},
-            {include_erts, false},
-            {overlay, [
-                {copy, "priv/genesis_testnet", "update/genesis"}
-            ]}
+            {include_erts, false}
+            %% pull genesis block from S3
         ]}
     ]},
     {docker_rosetta, [


### PR DESCRIPTION
Problems to fix: 
- The genesis block for testnet Docker images seems to be stale.
- The entrypoint and path for alpine flavored Dockerfiles was different from Ubuntu flavored Dockerfiles.
- The make target for `docker-build` did not work because our Dockerfiles now expect build arguments which are not supplied

Solutions: 
- Pull genesis blocks from S3 when building docker images.
- Fix makefile target.
- Make paths consistent across Dockerfiles.