### PR TITLE
fixes node crash caused by config file issue

### DIFF
--- a/config/prod.config
+++ b/config/prod.config
@@ -3,10 +3,10 @@
  "config/sys.config",
  {lager,
   [
-   {log_root, "/var/data/log/blockchain_node"}
+   {log_root, "log"}
   ]},
  {blockchain,
   [
-   {base_dir, "/var/data/blockchain_node"}
+   {base_dir, "data"}
   ]}
 ].


### PR DESCRIPTION
When starting the node, the node isn't able to find the `base_dir` with the original configuration. Aligns with the dev.config which used with the `make && make release` commands