### PR TITLE
implementing dockerignore file to restrict extraneous resource upload

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+_build/
+.buildkite/
+.git/


### PR DESCRIPTION
The blockchain-node repo doesn't currently have a dockerignore file which can cause any builds on a system where the host has previously compiled the app to copy a _build directory into the build container. This can cause problems in the final image artifact as the compiled app will likely be compiled for MacOS, BSD or a Linux flavor other than the Alpine Linux of the default runtime docker images for Helium Core apps.

Adding the `_build` directory will prevent this compilation architecture conflict and the `.buildkite` and `.git` directories will limit the volume of files sent into the docker build context which should provide marginal improvements to the build time and resource consumption.