### PR TITLE
fixing relx tagging confusion, updating pipeline

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# The `post-checkout` hook will run after the bootstrap script has checked out
+# your pipelines source code.
+
+set -euo pipefail
+
+git fetch --tags --force # avoid "would clobber existing tags error"
+git tag --points-at $(git rev-list -n 1 $BUILDKITE_TAG) | xargs -n 1 git tag -d || true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,8 +9,10 @@ steps:
 
   - if: build.tag != null && build.tag !~ /^otp/
     label: ":debian: build deb"
+    env:
+      VERSION_TAG: $BUILDKITE_TAG
     commands:
-      - "git fetch -t"
+      - "git tag $BUILDKITE_TAG"
       - ".buildkite/scripts/make_deb.sh prod"
     key: "deb"
     artifact_paths: "*.deb"
@@ -20,8 +22,9 @@ steps:
   - if: build.tag != null && build.tag !~ /^otp/
     label: "upload"
     name: ":cloud: upload to packagecloud"
+    env:
+      VERSION_TAG: $BUILDKITE_TAG
     commands:
-      - "git fetch -t"
       - ".buildkite/scripts/packagecloud_upload.sh"
     depends_on: "deb"
     agents:
@@ -30,26 +33,10 @@ steps:
   - if: build.tag != null && build.tag !~ /^otp/
     label: "prod docker"
     name: ":whale: build docker prod image"
+    env:
+      VERSION_TAG: $BUILDKITE_TAG
     commands:
-      - "git fetch -t"
+      - "git tag $BUILDKITE_TAG"
       - ".buildkite/scripts/make_docker.sh docker_node"
-    agents:
-      queue: "erlang"
-
-  - if: build.tag != null && build.tag !~ /^otp/
-    label: "docker"
-    name: ":whale: build rosetta docker image"
-    commands:
-      - "git fetch -t"
-      - ".buildkite/scripts/make_docker.sh docker_rosetta"
-    agents:
-      queue: "erlang"
-
-  - if: build.tag != null && build.tag !~ /^otp/
-    label: "docker"
-    name: ":whale: build rosetta testnet docker image"
-    commands:
-      - "git fetch -t"
-      - ".buildkite/scripts/make_docker.sh docker_rosetta_testnet"
     agents:
       queue: "erlang"

--- a/.buildkite/scripts/make_deb.sh
+++ b/.buildkite/scripts/make_deb.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION=$(echo $VERSION_TAG | sed -e 's/otp-//')
+VERSION=$VERSION_TAG
 
 DIAGNOSTIC=1 ./rebar3 as $1 release -v ${VERSION} -n blockchain_node
 

--- a/.buildkite/scripts/make_deb.sh
+++ b/.buildkite/scripts/make_deb.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION=$( git describe --abbrev=0 --tags )
+VERSION=$(echo $VERSION_TAG | sed -e 's/otp-//')
 
 DIAGNOSTIC=1 ./rebar3 as $1 release -v ${VERSION} -n blockchain_node
 

--- a/.buildkite/scripts/make_docker.sh
+++ b/.buildkite/scripts/make_docker.sh
@@ -7,7 +7,7 @@ BUILDER_IMAGE="erlang:24-alpine"
 RUNNER_IMAGE="alpine:3.15"
 
 BUILD_TARGET=$1
-VERSION=$(echo $VERSION_TAG | sed -e 's/otp-//')
+VERSION=$VERSION_TAG
 DOCKER_BUILD_ARGS="--build-arg VERSION=$VERSION --build-arg BUILD_TARGET=$BUILD_TARGET"
 
 case "$BUILD_TARGET" in

--- a/.buildkite/scripts/make_docker.sh
+++ b/.buildkite/scripts/make_docker.sh
@@ -7,7 +7,7 @@ BUILDER_IMAGE="erlang:24-alpine"
 RUNNER_IMAGE="alpine:3.15"
 
 BUILD_TARGET=$1
-VERSION=$( git describe --abbrev=0 )
+VERSION=$(echo $VERSION_TAG | sed -e 's/otp-//')
 DOCKER_BUILD_ARGS="--build-arg VERSION=$VERSION --build-arg BUILD_TARGET=$BUILD_TARGET"
 
 case "$BUILD_TARGET" in

--- a/.buildkite/scripts/packagecloud_upload.sh
+++ b/.buildkite/scripts/packagecloud_upload.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION=$( git describe --abbrev=0 --tags )
+VERSION=$(echo $VERSION_TAG | sed -e 's/otp-//')
 
 PKGNAME="blockchain-node_${VERSION}_amd64.deb"
 

--- a/.buildkite/scripts/packagecloud_upload.sh
+++ b/.buildkite/scripts/packagecloud_upload.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION=$(echo $VERSION_TAG | sed -e 's/otp-//')
+VERSION=$VERSION_TAG
 
 PKGNAME="blockchain-node_${VERSION}_amd64.deb"
 


### PR DESCRIPTION
Removing the rosetta docker images from the build pipeline since those were deprecated recently and do not have a dedicated Ubuntu-based image any longer.

Implementing the same tag management hooks and pre-build command steps to prevent `rebar3/relx` from getting confused by multiple git tags on the current build sha.