### PR TITLE
Pull ledger at specific height instead of relying on current ledger

### DIFF
--- a/src/bn_balances.erl
+++ b/src/bn_balances.erl
@@ -156,7 +156,6 @@ end_commit_hook(_CF, Changes) ->
         end,
         Changes
     ),
-    lager:info("end_commit_hook. Inserting ~p keys.", [length(Keys)]),
     ets:insert(?MODULE, Keys).
 
 %%
@@ -224,10 +223,9 @@ get_historic_entry(Key, Height0) ->
     end,
     {ok, BalanceIterator} = rocksdb:iterator(DB, EntriesCF, [{iterate_lower_bound, <<Key/binary, 0:64/integer-unsigned-big>>}, {total_order_seek, true}]),
     case rocksdb:iterator_move(BalanceIterator, {seek_for_prev, <<Key/binary, Height:64/integer-unsigned-big>>}) of
-        {ok, <<KeyBin:33/binary, HeightReturned:64/integer-unsigned-big>>, EntryBin} ->
-            lager:info("Key: ~p, Height Returned: ~p, for Height queried: ~p.", [?BIN_TO_B58(KeyBin), HeightReturned, Height]),
+        {ok, _, EntryBin} ->
             {ok, erlang:binary_to_term(EntryBin)};
-        {ok, _} ->            
+        {ok, _} ->
             {error, invalid_entry};
         {error, Error} ->
             {error, Error}

--- a/src/bn_balances.erl
+++ b/src/bn_balances.erl
@@ -62,8 +62,7 @@ load_block(_Hash, Block, _Sync, _Ledger, State = #state{
 }) ->
     Height = blockchain_block:height(Block),
     case blockchain:ledger_at(Height, blockchain_worker:blockchain()) of
-        {error, _} ->
-            Height = blockchain_block:height(Block),
+        {error, _} -> 
             bn_db:put_follower_height(DB, DefaultCF, Height),
             {ok, State};
         {ok, Ledger} ->

--- a/src/bn_gateways.erl
+++ b/src/bn_gateways.erl
@@ -60,18 +60,17 @@ follower_height(#state{db = DB, default = DefaultCF}) ->
 load_chain(_Chain, State = #state{}) ->
     {ok, State}.
 
-load_block(_Hash, Block, _Sync, Ledger, State = #state{
+load_block(_Hash, Block, _Sync, _Ledger, State = #state{
     db=DB, 
     default=DefaultCF, 
     historic_gateways=HistoricGatewaysCF
 }) ->
-    case Ledger of
-        undefined ->
-            Height = blockchain_block:height(Block),
+    Height = blockchain_block:height(Block),
+    case blockchain:ledger_at(Height, blockchain_worker:blockchain()) of
+        {error, _} -> 
             bn_db:put_follower_height(DB, DefaultCF, Height),
             {ok, State};
-        _ ->
-            {ok, Height} = blockchain_ledger_v1:current_height(Ledger),
+        {ok, Ledger} ->
             case rocksdb:get(DB, DefaultCF, <<"loaded_initial_gateways">>, []) of
                 not_found ->
                     {ok, Batch} = rocksdb:batch(),


### PR DESCRIPTION
Eliminating a race condition where the referenced ledger would sometimes be one block ahead of the current block being loaded by `load_block`.