### PR TITLE
Remove commit_hook_callbacks from sys.config

### DIFF
--- a/config/docker_rosetta.config
+++ b/config/docker_rosetta.config
@@ -20,6 +20,16 @@
    {store_htlc_receipts, true},
    {store_historic_balances, true},
    {store_historic_gateways, true},
+   {commit_hook_callbacks, [
+      {entries, undefined, fun bn_balances:incremental_commit_hook/1,
+          fun bn_balances:end_commit_hook/2},
+      {dc_entries, undefined, fun bn_balances:incremental_commit_hook/1,
+          fun bn_balances:end_commit_hook/2},
+      {securities, undefined, fun bn_balances:incremental_commit_hook/1,
+          fun bn_balances:end_commit_hook/2},
+      {active_gateways, undefined, fun bn_gateways:incremental_commit_hook/1,
+          fun bn_gateways:end_commit_hook/2}
+   ]},
    {snap_source_base_url, "https://snapshots.helium.wtf/mainnet"},
    {fetch_latest_from_snap_source, false}
   ]}

--- a/config/docker_rosetta_testnet.config
+++ b/config/docker_rosetta_testnet.config
@@ -25,6 +25,16 @@
    {store_htlc_receipts, true},
    {store_historic_balances, true},
    {store_historic_gateways, true},
+   {commit_hook_callbacks, [
+      {entries, undefined, fun bn_balances:incremental_commit_hook/1,
+          fun bn_balances:end_commit_hook/2},
+      {dc_entries, undefined, fun bn_balances:incremental_commit_hook/1,
+          fun bn_balances:end_commit_hook/2},
+      {securities, undefined, fun bn_balances:incremental_commit_hook/1,
+          fun bn_balances:end_commit_hook/2},
+      {active_gateways, undefined, fun bn_gateways:incremental_commit_hook/1,
+          fun bn_gateways:end_commit_hook/2}
+   ]},
    {snap_source_base_url, "https://snapshots.helium.wtf/testnet"},
    {fetch_latest_from_snap_source, false}
   ]}

--- a/config/sys.config
+++ b/config/sys.config
@@ -42,16 +42,6 @@
         {store_htlc_receipts, false},
         {store_implicit_burns, false},
         {store_historic_balances, false},
-        {commit_hook_callbacks, [
-            {entries, undefined, fun bn_balances:incremental_commit_hook/1,
-                fun bn_balances:end_commit_hook/2},
-            {dc_entries, undefined, fun bn_balances:incremental_commit_hook/1,
-                fun bn_balances:end_commit_hook/2},
-            {securities, undefined, fun bn_balances:incremental_commit_hook/1,
-                fun bn_balances:end_commit_hook/2},
-            {active_gateways, undefined, fun bn_gateways:incremental_commit_hook/1,
-                fun bn_gateways:end_commit_hook/2}
-        ]},
         {key, undefined},
         {base_dir, "data"},
         {autoload, false},


### PR DESCRIPTION
Realized that commit_hook_callbacks regarding historic data should not live in sys.config. Moved to docker_rosetta* configs. 

**Be advised that currently the active_gateways callback is crashing the node. Recommendation is to merge this ASAP and tag a hotfix release.**