### PR TITLE
Tolerate state channel open as pending txn

### DIFF
--- a/src/bn_pending_txns.erl
+++ b/src/bn_pending_txns.erl
@@ -27,7 +27,7 @@
     | #blockchain_txn_transfer_validator_stake_v1_pb{}
     | #blockchain_txn_state_channel_open_v1_pb{}.
 
--type nonce_type() :: none | balance | gateway | security | oui.
+-type nonce_type() :: none | balance | gateway | security | dc_nonce.
 -type nonce_address() :: libp2p_crypto:pubkey_bin() | undefined.
 -type nonce() :: non_neg_integer().
 
@@ -350,7 +350,7 @@ nonce_info(#blockchain_txn_transfer_validator_stake_v1_pb{old_address = Address}
 nonce_info(#blockchain_txn_unstake_validator_v1_pb{address = Address}) ->
     {Address, 0, none};
 nonce_info(#blockchain_txn_state_channel_open_v1_pb{owner = Address, nonce = Nonce}) ->
-    {Address, Nonce, oui};
+    {Address, Nonce, dc_nonce};
 nonce_info(_) ->
     undefined.
 

--- a/src/bn_pending_txns.erl
+++ b/src/bn_pending_txns.erl
@@ -27,7 +27,7 @@
     | #blockchain_txn_transfer_validator_stake_v1_pb{}
     | #blockchain_txn_state_channel_open_v1_pb{}.
 
--type nonce_type() :: none | balance | gateway | security | dc_nonce.
+-type nonce_type() :: none | balance | gateway | security | dc.
 -type nonce_address() :: libp2p_crypto:pubkey_bin() | undefined.
 -type nonce() :: non_neg_integer().
 
@@ -350,7 +350,7 @@ nonce_info(#blockchain_txn_transfer_validator_stake_v1_pb{old_address = Address}
 nonce_info(#blockchain_txn_unstake_validator_v1_pb{address = Address}) ->
     {Address, 0, none};
 nonce_info(#blockchain_txn_state_channel_open_v1_pb{owner = Address, nonce = Nonce}) ->
-    {Address, Nonce, dc_nonce};
+    {Address, Nonce, dc};
 nonce_info(_) ->
     undefined.
 

--- a/src/bn_pending_txns.erl
+++ b/src/bn_pending_txns.erl
@@ -24,9 +24,10 @@
     | #blockchain_txn_security_exchange_v1_pb{}
     | #blockchain_txn_stake_validator_v1_pb{}
     | #blockchain_txn_unstake_validator_v1_pb{}
-    | #blockchain_txn_transfer_validator_stake_v1_pb{}.
+    | #blockchain_txn_transfer_validator_stake_v1_pb{}
+    | #blockchain_txn_state_channel_open_v1_pb{}.
 
--type nonce_type() :: none | balance | gateway | security.
+-type nonce_type() :: none | balance | gateway | security | oui.
 -type nonce_address() :: libp2p_crypto:pubkey_bin() | undefined.
 -type nonce() :: non_neg_integer().
 
@@ -299,7 +300,7 @@ get_max_nonce(Address, NonceType, Itr, {ok, _, BinTxn}, Acc) ->
 %% includes the actor whose nonce is impacted, the nonce in the transaction and %
 %% the type of nonce this is.
 %%
-%% NOTE: This list should include all tranaction types that can be submitted to
+%% NOTE: This list should include all transaction types that can be submitted to
 %% the endpoint. We try to make it match what blockchain-http supports.
 -spec nonce_info(supported_txn()) -> {nonce_address(), nonce(), nonce_type()}.
 nonce_info(#blockchain_txn_oui_v1_pb{owner = Owner}) ->
@@ -347,7 +348,11 @@ nonce_info(#blockchain_txn_stake_validator_v1_pb{address = Address}) ->
 nonce_info(#blockchain_txn_transfer_validator_stake_v1_pb{old_address = Address}) ->
     {Address, 0, none};
 nonce_info(#blockchain_txn_unstake_validator_v1_pb{address = Address}) ->
-    {Address, 0, none}.
+    {Address, 0, none};
+nonce_info(#blockchain_txn_state_channel_open_v1_pb{owner = Address, nonce = Nonce}) ->
+    {Address, Nonce, oui};
+nonce_info(_) ->
+    undefined.
 
 -spec load_db(Dir :: file:filename_all()) -> {ok, #state{}} | {error, any()}.
 load_db(Dir) ->


### PR DESCRIPTION
I have a blockchain-node on testnet where I open and close state channels. However, whenever an open state channel transaction was pending, the account_get endpoint would crash:

```
2022-01-27 20:32:04.704 [error] <0.1274.0> Error in JSON-RPC handler for method account_get with params {[{<<"address">>,<<"1be3xdTQTYX8UbA5ND5F1cKcGEw1BSD2akyFtXbJkxDm5JtLzzD">>}]} (id: <<"1643315524655">>): error:function_clause from [{bn_pending_txns,nonce_info,[{blockchain_txn_state_channel_open_v1_pb,<<117,139,243,143,75,233,183,249,228,210,16,248,91,133,36,123,54,203,79,57,156,95,106,15,236,204,60,225,123,126,100,188>>,<<17,119,78,174,39,124,3,221,230,72,158,129,54,32,7,121,201,19,129,53,45,7,156,186,254,48,11,46,80,112,75,253,176>>,10000,16,4,5,<<161,67,138,169,73,163,144,110,167,49,16,219,120,30,229,156,102,80,207,121,14,49,52,151,115,155,111,163,142,235,111,206,96,14,181,74,213,173,9,176,76,63,186,89,212,201,217,25,118,185,139,213,4,143,198,82,169,244,198,75,186,135,163,7>>,35000}],
[{file,"/opt/build/blockchain-node/src/bn_pending_txns.erl"},{line,318}]},{bn_pending_txns,get_max_nonce,5,
[{file,"/opt/build/blockchain-node/src/bn_pending_txns.erl"},{line,301}]},{bn_pending_txns,get_max_nonce,3,
[{file,"/opt/build/blockchain-node/src/bn_pending_txns.erl"},{line,293}]},{bn_accounts,get_speculative_nonce,3,
[{file,"/opt/build/blockchain-node/src/bn_accounts.erl"},{line,135}]},{bn_accounts,'-handle_rpc/2-fun-0-',2,
[{file,"/opt/build/blockchain-node/src/bn_accounts.erl"},{line,67}]},{bn_accounts,'-handle_rpc/2-fun-3-',2,
[{file,"/opt/build/blockchain-node/src/bn_accounts.erl"},{line,113}]},{lists,foldl,3,[{file,"lists.erl"},{line,1263}]},{jsonrpc2,dispatch,2,[{file,"/opt/build/blockchain-node/_build/default/lib/jsonrpc2/src/jsonrpc2.erl"},{line,194}]}]
```

I think what I understood was that `bn_pending_txns:nonce_info` has a sad time when it tries to handle an "unsupported" transaction.

I added a default handler but I also laid some groundwork for tolerating an oui nonce. 