### PR TITLE
ara/implement-cd

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -32,7 +32,7 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         - name: Install Dependencies
           run: |
-            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev libpcl-dev build-essential
+            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev liblz4-dev build-essential
         - name: Build tarball
           run: |
             make tar PROFILE=${{ matrix.builds }}

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -14,6 +14,7 @@ jobs:
       
       name: Upload Release Asset
       runs-on: ubuntu-20.04
+      timeout-minutes: 30
       strategy:
         matrix:
           otp: ['24.2']
@@ -32,7 +33,7 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         - name: Install Dependencies
           run: |
-            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev liblz4-dev build-essential
+            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev librocksdb-dev build-essential
         - name: Build tarball
           run: |
             make tar PROFILE=${{ matrix.builds }}

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -19,7 +19,8 @@ jobs:
           otp: ['24.2']
           rebar3: ['3.15.1']
       steps:
-        - uses: actions/checkout@v2
+        - name: Checkout Repo
+          uses: actions/checkout@v2
         - name: Install Erlang OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
           uses: erlef/setup-beam@v1
           with:
@@ -32,7 +33,8 @@ jobs:
             toolchain: stable
             override: true
         - name: Install Dependencies
-          run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev autoconf automake libtool flex libgmp-dev cmake libsodium-dev libssl-dev bison libsnappy-dev libclang-dev doxygen
+          run: |
+            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev build-essential
         - name: Build tarball
           run: |
             make tar PROFILE=prod

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -13,30 +13,36 @@ jobs:
     build:
       
       name: Upload Release Asset
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       timeout-minutes: 30
       strategy:
         matrix:
           otp: ['24.2']
           rebar3: ['3.15.1']
           builds: ['prod', 'testnet']
+      
       steps:
         - name: Checkout Repo
           uses: actions/checkout@v2
+
         - name: Install Erlang OTP ${{ matrix.otp }} / rebar3 ${{ matrix.rebar3 }}
           uses: erlef/setup-beam@v1
           with:
             otp-version: ${{ matrix.otp }}
             rebar3-version: ${{ matrix.rebar3 }}
+        
         - name: Install stable rustup
           run: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        
         - name: Install Dependencies
           run: |
-            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev liblz4-dev && sudo rm -rf /var/lib/apt/lists/*
+            sudo apt-get install -y cmake libsodium-dev liblz4-dev
+        
         - name: Build tarball
           run: |
             make tar PROFILE=${{ matrix.builds }}
+        
         - name: Create Release
           id: create_release
           uses: actions/create-release@v1
@@ -47,6 +53,7 @@ jobs:
             release_name: ${{ github.ref_name }}
             draft: false
             prerelease: false
+        
         - name: Upload Release Asset
           id: upload-release-asset 
           uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -27,12 +27,9 @@ jobs:
           with:
             otp-version: ${{matrix.otp}}
             rebar3-version: ${{matrix.rebar3}}
-        - name: Install latest rust toolchain
-          uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-            toolchain: stable
-            override: true
+        - name: Install stable rustup
+          run: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
         - name: Install Dependencies
           run: |
             sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev build-essential

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -33,7 +33,7 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         - name: Install Dependencies
           run: |
-            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev lz4 build-essential
+            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev liblz4-dev && rm -rf /var/lib/apt/lists/*
         - name: Build tarball
           run: |
             make tar PROFILE=${{ matrix.builds }}

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -105,3 +105,4 @@ jobs:
             files: |
               testnet-node-${{ github.ref_name }}.tar.gz
               prod-node-${{ github.ref_name }}.tar.gz
+              

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -13,29 +13,46 @@ jobs:
     build:
       
       name: Upload Release Asset
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
+      timeout-minutes: 30
+
+      env:
+        ERLANG_ROCKSDB_OPTS: "-DWITH_BUNDLE_SNAPPY=ON -DWITH_BUNDLE_LZ4=ON"
+        ERL_COMPILER_OPTIONS: "[deterministic]" 
+
       strategy:
         matrix:
           otp: ['24.2']
           rebar3: ['3.15.1']
           builds: ['prod', 'testnet']
+      
       steps:
         - name: Checkout Repo
           uses: actions/checkout@v2
+
         - name: Install Erlang OTP ${{ matrix.otp }} / rebar3 ${{ matrix.rebar3 }}
           uses: erlef/setup-beam@v1
           with:
             otp-version: ${{ matrix.otp }}
             rebar3-version: ${{ matrix.rebar3 }}
+        
         - name: Install stable rustup
           run: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        
         - name: Install Dependencies
           run: |
-            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev liblz4-dev build-essential
+            sudo apt-get install -y libsodium-dev liblz4-dev
+        
+        - name: Setup cmake
+          uses: jwlawson/actions-setup-cmake@v1.12
+          with:
+            cmake-version: '3.16.x'
+
         - name: Build tarball
           run: |
             make tar PROFILE=${{ matrix.builds }}
+        
         - name: Create Release
           id: create_release
           uses: actions/create-release@v1
@@ -46,6 +63,7 @@ jobs:
             release_name: ${{ github.ref_name }}
             draft: false
             prerelease: false
+        
         - name: Upload Release Asset
           id: upload-release-asset 
           uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -25,11 +25,14 @@ jobs:
           with:
             otp-version: ${{matrix.otp}}
             rebar3-version: ${{matrix.rebar3}}
-        - name: Install latest rustup
+        - name: Install latest rust toolchain
           uses: actions-rs/toolchain@v1
           with:
+            profile: minimal
             toolchain: stable
             override: true
+        - name: Install Dependencies
+          run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev autoconf automake libtool flex libgmp-dev cmake libsodium-dev libssl-dev bison libsnappy-dev libclang-dev doxygen
         - name: Build tarball
           run: |
             make tar PROFILE=prod

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -17,9 +17,6 @@ jobs:
       timeout-minutes: 30
 
       env:
-        CC: gcc
-        CXX: g++
-        CFLAGS: "-U__sun__"
         ERLANG_ROCKSDB_OPTS: "-DWITH_BUNDLE_SNAPPY=ON -DWITH_BUNDLE_LZ4=ON"
         ERL_COMPILER_OPTIONS: "[deterministic]" 
 

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -20,10 +20,16 @@ jobs:
           rebar3: ['3.15.1']
       steps:
         - uses: actions/checkout@v2
-        - uses: erlef/setup-beam@v1
+        - name: Install Erlang OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
+          uses: erlef/setup-beam@v1
           with:
             otp-version: ${{matrix.otp}}
             rebar3-version: ${{matrix.rebar3}}
+        - name: Install latest rustup
+          uses: actions-rs/toolchain@v1
+          with:
+            toolchain: stable
+            override: true
         - name: Build tarball
           run: |
             make tar PROFILE=prod

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -1,4 +1,4 @@
-name: Build Release Assets
+name: Build and Release
    
 on:
   push:
@@ -6,71 +6,102 @@ on:
       - '*'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-    
-    build:
-      
-      name: Upload Release Asset
+    testnet:
+      name: Build Testnet
       runs-on: ubuntu-latest
-      timeout-minutes: 30
 
       env:
         ERLANG_ROCKSDB_OPTS: "-DWITH_BUNDLE_SNAPPY=ON -DWITH_BUNDLE_LZ4=ON"
         ERL_COMPILER_OPTIONS: "[deterministic]" 
-
-      strategy:
-        matrix:
-          otp: ['24.2']
-          rebar3: ['3.15.1']
-          builds: ['prod', 'testnet']
-          
+      
       steps:
         - name: Checkout Repo
           uses: actions/checkout@v2
 
-        - name: Install Erlang OTP ${{ matrix.otp }} / rebar3 ${{ matrix.rebar3 }}
-          uses: erlef/setup-beam@v1
+        - name: Setup Build Environment
+          uses: anthonyra/helium-erlang-builder-action@v1.2
           with:
-            otp-version: ${{ matrix.otp }}
-            rebar3-version: ${{ matrix.rebar3 }}
-        
-        - name: Install stable rustup
-          run: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        
-        - name: Install Dependencies
-          run: |
-            sudo apt-get install -y libsodium-dev liblz4-dev
-        
-        - name: Setup cmake
-          uses: jwlawson/actions-setup-cmake@v1.12
-          with:
-            cmake-version: '3.16.x'
+            otp-version: '24.2'
+            rebar3-version: '3.15.1'
 
-        - name: Build tarball
+        - name: Build Tar
           run: |
-            make tar PROFILE=${{ matrix.builds }}
+            make tar PROFILE=${{ github.job }}
+
+        - name: Upload Tar Artifact
+          uses: actions/upload-artifact@v2
+          with:
+            name: testnet-node
+            path: |
+              ./builds/${{ github.job }}/blockchain_node/blockchain_node-${{ github.ref_name }}.tar.gz
+
+    prod:
+      name: Build Production
+      runs-on: ubuntu-latest
+
+      env:
+        ERLANG_ROCKSDB_OPTS: "-DWITH_BUNDLE_SNAPPY=ON -DWITH_BUNDLE_LZ4=ON"
+        ERL_COMPILER_OPTIONS: "[deterministic]" 
+      
+      steps:
+        - name: Checkout Repo
+          uses: actions/checkout@v2
+
+        - name: Setup Build Environment
+          uses: anthonyra/helium-erlang-builder-action@v1.2
+          with:
+            otp-version: '24.2'
+            rebar3-version: '3.15.1'
+
+        - name: Build Tar
+          run: |
+            make tar PROFILE=${{ github.job }}
+
+        - name: Upload Tar Artifact
+          uses: actions/upload-artifact@v2
+          with:
+            name: prod-node
+            path: |
+              ./builds/${{ github.job }}/blockchain_node/blockchain_node-${{ github.ref_name }}.tar.gz
+
+    release:
+      name: Create Release
+      needs: [testnet, prod]
+      runs-on: ubuntu-latest
         
+      steps:
+        - name: Checkout Repo
+          uses: actions/checkout@v2
+
+        - name: Download Testnet Build
+          id: testnet
+          uses: actions/download-artifact@v2
+          with:
+            name: testnet-node
+
+        - name: Rename Testnet Build
+          working-directory: ${{steps.testnet.outputs.download-path}}
+          run: |
+            sudo mv ./blockchain_node-${{ github.ref_name }}.tar.gz ./testnet-node-${{ github.ref_name }}.tar.gz
+
+        - name: Download Production Build
+          id: prod
+          uses: actions/download-artifact@v2
+          with:
+            name: prod-node
+
+        - name: Rename Production Build
+          working-directory: ${{steps.prod.outputs.download-path}}
+          run:  |
+            sudo mv ./blockchain_node-${{ github.ref_name }}.tar.gz ./prod-node-${{ github.ref_name }}.tar.gz
+
         - name: Create Release
-          id: create_release
-          uses: actions/create-release@v1
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          uses: softprops/action-gh-release@v1
           with:
-            tag_name: ${{ github.ref }}
-            release_name: ${{ github.ref_name }}
-            draft: false
-            prerelease: false
-        
-        - name: Upload Release Asset
-          id: upload-release-asset 
-          uses: actions/upload-release-asset@v1
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-            asset_path: ./builds/blockchain_node/blockchain_node-${{ github.ref_name }}.tar.gz
-            asset_name: ${{ matrix.builds }}-node-${{ github.ref_name }}.tar.gz
-            asset_content_type: application/tar+gzip      
+            body_path: CHANGELOG.md
+            files: |
+              testnet-node-${{ github.ref_name }}.tar.gz
+              prod-node-${{ github.ref_name }}.tar.gz

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -33,7 +33,7 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         - name: Install Dependencies
           run: |
-            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev librocksdb-dev build-essential
+            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev lz4 build-essential
         - name: Build tarball
           run: |
             make tar PROFILE=${{ matrix.builds }}

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -13,13 +13,17 @@ jobs:
     build:
       
       name: Upload Release Asset
-      runs-on: ubuntu-latest
-      container:
-        image: erlang:24-alpine
-    
+      runs-on: ubuntu-20.04
+      strategy:
+        matrix:
+          otp: ['24.2']
+          rebar3: ['3.15.1']
       steps:
-        - name: Checkout code
-          uses: actions/checkout@v2
+        - uses: actions/checkout@v2
+        - uses: erlef/setup-beam@v1
+          with:
+            otp-version: ${{matrix.otp}}
+            rebar3-version: ${{matrix.rebar3}}
         - name: Build tarball
           run: |
             make tar PROFILE=prod
@@ -42,5 +46,4 @@ jobs:
             upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
             asset_path: ./builds/blockchain_node/blockchain_node-${{ github.ref_name }}.tar.gz
             asset_name: node-${{ github.ref_name }}.tar.gz
-            asset_content_type: application/tar+gzip
-            
+            asset_content_type: application/tar+gzip      

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -29,7 +29,7 @@ jobs:
             rebar3-version: ${{matrix.rebar3}}
         - name: Install stable rustup
           run: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         - name: Install Dependencies
           run: |
             sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev build-essential

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -15,6 +15,14 @@ jobs:
       name: Upload Release Asset
       runs-on: ubuntu-latest
       timeout-minutes: 30
+
+      env:
+        CC: gcc
+        CXX: g++
+        CFLAGS: "-U__sun__"
+        ERLANG_ROCKSDB_OPTS: "-DWITH_BUNDLE_SNAPPY=ON -DWITH_BUNDLE_LZ4=ON"
+        ERL_COMPILER_OPTIONS: "[deterministic]" 
+
       strategy:
         matrix:
           otp: ['24.2']
@@ -43,9 +51,6 @@ jobs:
           uses: jwlawson/actions-setup-cmake@v1.12
           with:
             cmake-version: '3.16.x'
-            
-        - name: Use cmake
-          run: cmake --version
 
         - name: Build tarball
           run: |

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -33,7 +33,7 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         - name: Install Dependencies
           run: |
-            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev liblz4-dev && rm -rf /var/lib/apt/lists/*
+            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev liblz4-dev && sudo rm -rf /var/lib/apt/lists/*
         - name: Build tarball
           run: |
             make tar PROFILE=${{ matrix.builds }}

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -37,8 +37,16 @@ jobs:
         
         - name: Install Dependencies
           run: |
-            sudo apt-get install -y cmake libsodium-dev liblz4-dev
+            sudo apt-get install -y libsodium-dev liblz4-dev
         
+        - name: Setup cmake
+          uses: jwlawson/actions-setup-cmake@v1.12
+          with:
+            cmake-version: '3.16.x'
+            
+        - name: Use cmake
+          run: cmake --version
+
         - name: Build tarball
           run: |
             make tar PROFILE=${{ matrix.builds }}

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -22,20 +22,20 @@ jobs:
       steps:
         - name: Checkout Repo
           uses: actions/checkout@v2
-        - name: Install Erlang OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
+        - name: Install Erlang OTP ${{ matrix.otp }} / rebar3 ${{ matrix.rebar3 }}
           uses: erlef/setup-beam@v1
           with:
-            otp-version: ${{matrix.otp}}
-            rebar3-version: ${{matrix.rebar3}}
+            otp-version: ${{ matrix.otp }}
+            rebar3-version: ${{ matrix.rebar3 }}
         - name: Install stable rustup
           run: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         - name: Install Dependencies
           run: |
-            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev build-essential
+            sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev libpcl-dev build-essential
         - name: Build tarball
           run: |
-            make tar PROFILE=${{matrix.builds}}
+            make tar PROFILE=${{ matrix.builds }}
         - name: Create Release
           id: create_release
           uses: actions/create-release@v1
@@ -53,6 +53,6 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           with:
             upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-            asset_path: ./builds/${{matrix.builds}}/blockchain_node/blockchain_node-${{ github.ref_name }}.tar.gz
-            asset_name: node-${{ github.ref_name }}.tar.gz
+            asset_path: ./builds/blockchain_node/blockchain_node-${{ github.ref_name }}.tar.gz
+            asset_name: ${{ matrix.builds }}-node-${{ github.ref_name }}.tar.gz
             asset_content_type: application/tar+gzip      

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -24,7 +24,7 @@ jobs:
         matrix:
           otp: ['24.2']
           rebar3: ['3.15.1']
-          builds: ['prod', 'testnet']
+          builds: ['prod']
       
       steps:
         - name: Checkout Repo

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -18,6 +18,7 @@ jobs:
         matrix:
           otp: ['24.2']
           rebar3: ['3.15.1']
+          builds: ['prod', 'testnet']
       steps:
         - name: Checkout Repo
           uses: actions/checkout@v2
@@ -37,7 +38,7 @@ jobs:
             sudo apt-get update && sudo apt-get install -y cmake libsodium-dev libssl-dev build-essential
         - name: Build tarball
           run: |
-            make tar PROFILE=prod
+            make tar PROFILE=${{matrix.builds}}
         - name: Create Release
           id: create_release
           uses: actions/create-release@v1
@@ -55,6 +56,6 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           with:
             upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-            asset_path: ./builds/blockchain_node/blockchain_node-${{ github.ref_name }}.tar.gz
+            asset_path: ./builds/${{matrix.builds}}/blockchain_node/blockchain_node-${{ github.ref_name }}.tar.gz
             asset_name: node-${{ github.ref_name }}.tar.gz
             asset_content_type: application/tar+gzip      

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,0 +1,46 @@
+name: Build Release Assets
+   
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: read
+
+jobs:
+    
+    build:
+      
+      name: Upload Release Asset
+      runs-on: ubuntu-latest
+      container:
+        image: erlang:24-alpine
+    
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+        - name: Build tarball
+          run: |
+            make tar PROFILE=prod
+        - name: Create Release
+          id: create_release
+          uses: actions/create-release@v1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            tag_name: ${{ github.ref }}
+            release_name: ${{ github.ref_name }}
+            draft: false
+            prerelease: false
+        - name: Upload Release Asset
+          id: upload-release-asset 
+          uses: actions/upload-release-asset@v1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+            asset_path: ./builds/blockchain_node/blockchain_node-${{ github.ref_name }}.tar.gz
+            asset_name: node-${{ github.ref_name }}.tar.gz
+            asset_content_type: application/tar+gzip
+            

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+### ADDED
+
+- Implement commit hooks with heights
+
+### Updated
+
+- Upgrades blockchain-core to latest as of 2022.03.07.0
+
+# Notes
+
+Please upgrade to `v1.1.61` by 03/25/2022 00:00 UTC to ensure chain variable support so that your local blockchain node is able to continue absorbing transactions.

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ release:
 	$(REBAR) as $(PROFILE) do release
 
 tar:
-	$(REBAR) as $(PROFILE) do tar --output-dir=$(BUILDS_DIR)/$(PROFILE)
+	$(REBAR) as $(PROFILE) do tar --output-dir=$(BUILDS_DIR)
 
 .PHONY: docs
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ release:
 	$(REBAR) as $(PROFILE) do release
 
 tar:
-	$(REBAR) as $(PROFILE) do tar --output-dir=$(BUILDS_DIR)
+	$(REBAR) as $(PROFILE) do tar --output-dir=$(BUILDS_DIR)/$(PROFILE)
 
 .PHONY: docs
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ APP_VERSION=$$(git tag --points-at HEAD)
 
 OS_NAME=$(shell uname -s)
 PROFILE ?= dev
+BUILDS_DIR ?= ./builds
 
 ifeq (${OS_NAME},FreeBSD)
 make="gmake"
@@ -40,6 +41,9 @@ doc:
 
 release:
 	$(REBAR) as $(PROFILE) do release
+
+tar:
+	$(REBAR) as $(PROFILE) do tar --output-dir=$(BUILDS_DIR)
 
 .PHONY: docs
 

--- a/rebar.config
+++ b/rebar.config
@@ -99,6 +99,14 @@
             {include_erts, false}
         ]}
     ]},
+    {prod, [
+        {relx, [
+            {sys_config, "./config/prod.config"},
+            {dev_mode, false},
+            {include_src, false},
+            {include_erts, true}
+        ]}
+    ]},
     {dev_testnet, [
         {relx, [
             {sys_config, "./config/dev_testnet.config"},
@@ -110,12 +118,15 @@
             ]}
         ]}
     ]},
-    {prod, [
+    {testnet, [
         {relx, [
-            {sys_config, "./config/prod.config"},
-            {dev_mode, false},
+            {sys_config, "./config/dev_testnet.config"},
+            {dev_mode, true},
             {include_src, false},
-            {include_erts, true}
+            {include_erts, true},
+            {overlay, [
+                {copy, "priv/genesis_testnet", "update/genesis"}
+            ]}
         ]}
     ]},
     {docker_node, [


### PR DESCRIPTION
Implements a Github Action that builds a pre packaged binary (tarball) via `./rebar3 as ${PROFILE} do tar` for blockchain-node for both production and testnet.

On my side all steps up to the create release step passes. I believe the create release fails for me since I don't have permissions to create a release. [Reference Document](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

Process:

1. Trigger Github Action on pushing a new tag. Name needs to follow current convention of `1.1.62`
2. Builds tarballs for production and testnet
3. Creates release
4. Uploads `prod-node-1.1.62.tar.gz` and `testnet-node-1.1.62.tar.gz`

TODO

- [ ] Test Create Release Step (I don't have permissions to create a release) - most likely needs
```yaml
permissions:
      contents: write
```
- [ ] Make sure the tag body is also added to the new release
- [ ] Test Upload Release Asset
- [ ] Compare builds from Docker and Source to ensure proper builds

In Support dewi-alliance/grants#24