### PR TITLE
runtime image must be same as build time image base

### DIFF
--- a/.buildkite/scripts/make_docker.sh
+++ b/.buildkite/scripts/make_docker.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 REGISTRY_HOST="quay.io/team-helium/blockchain-node"
 BUILDER_IMAGE="erlang:24-alpine"
-RUNNER_IMAGE="alpine:3.15"
+RUNNER_IMAGE="alpine:3.16"
 
 BUILD_TARGET=$1
 VERSION=$VERSION_TAG

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 REBAR=./rebar3
 BUILDER_IMAGE=erlang:24-alpine
-RUNNER_IMAGE=alpine:3.15
+RUNNER_IMAGE=alpine:3.16
 APP_VERSION=$$(git tag --points-at HEAD)
 
 OS_NAME=$(shell uname -s)


### PR DESCRIPTION
Make sure the runtime image is compatible with the build image's alpine base version since the location of some libraries has changed. This mismatch on some very recent (past 3-6 days) builds of miner are causing `no symbol found` errors when trying to perform runtime release unpacking actions as part of the application boot sequence