### PR TITLE
Jg/last reward grpc api

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -69,7 +69,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.18.1">>},1},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"a9c1d484e117384c195e0980bd0225c219f78996"}},
+       {ref,"1d9d8550e332411dd52ed18773883cb2e33476d7"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},3},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.1.1">>},2},


### PR DESCRIPTION
depends on https://github.com/helium/proto/pull/166 and updating rebar.lock to point the proto repo back to the master branch once merged.

this change implements the grpc unary api that will return to the caller the last reward height recorded for the given subnet (as recorded in the `end_epoch` field of the animal's `blockchain_txn_subnetwork_rewards_v1` record. this adds the endpoint to the grpcbox follower service running in the node as well as better handling errors related to requests received to either unary endpoint that require a handle to the chain before continuing operations when called.