### PR TITLE
Bump core to include chain var modification

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},1},
  {<<"blockchain">>,
   {git,"https://github.com/helium/blockchain-core.git",
-       {ref,"b6aca665dfa1cf5bdf81bf4c410275a463b0cc0c"}},
+       {ref,"4323004323f1b943f518643f0973dd361126d38e"}},
   0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},2},
  {<<"chatterbox">>,


### PR DESCRIPTION
Adds support for allowing resolution 5 h3 hex garbage collection

https://github.com/helium/blockchain-core/pull/1471