### PR TITLE
fix exported proto service names

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -65,8 +65,8 @@
                     #{
                         service_protos => [follower_pb, transaction_pb],
                         services => #{
-                            'helium.follower' => helium_follower_service,
-                            'helium.transaction' => helium_transaction_service
+                            'helium.follower.follower' => helium_follower_service,
+                            'helium.transaction.transaction' => helium_transaction_service
                         }
                     },
                 transport_opts => #{ssl => false},


### PR DESCRIPTION
grpcbox doesn't hide enough of how the sausage is made for this service endpoint definition to be abstracted away from the server implementing the proto servers. the service endpoints grpcbox creates are the concatenation of the proto package and the service name.