### PR TITLE
Broken Symbolic Link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV COOKIE=node \
 
 COPY --from=builder /opt/docker ./
 
-RUN ln -sf releases/$VERSION /config
+RUN ln -sf /opt/blockchain_node/releases/$VERSION /config
 
 ENTRYPOINT ["bin/blockchain_node"]
 CMD ["foreground"]


### PR DESCRIPTION
On line 59, the command creates a broken symbolic link. I realized this after inspecting the internal filesystem of the Container. Need to specify the entire path such as /opt/blockchain_node/releases/$VERSION.