### PR TITLE
adding debug info to the prod release profile

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -139,6 +139,7 @@
             {release, {blockchain_node, semver}, [blockchain_node]},
             {sys_config, "./config/prod.config"},
             {dev_mode, false},
+            {debug_info, keep},
             {include_src, false},
             {include_erts, true}
         ]}


### PR DESCRIPTION
we need the debug symbols to remain _not_ stripped from the compiled binary