### PR TITLE
Patch load_chain for follower modules

### DIFF
--- a/src/bn_oracle_price.erl
+++ b/src/bn_oracle_price.erl
@@ -53,7 +53,12 @@ follower_height(#state{db = DB, default = DefaultCF}) ->
         {error, _} = Error -> ?jsonrpc_error(Error)
     end.
 
-load_chain(_Chain, State = #state{}) ->
+load_chain(Chain, State = #state{db = DB, default = CF}) ->
+    {ok, Height} = blockchain:height(Chain),
+    case bn_db:get_follower_height(DB, CF) of
+        {ok, 0} -> bn_db:put_follower_height(DB, CF, Height);
+        _ -> ok
+    end,
     {ok, State}.
 
 load_block(_Hash, Block, _Sync, Ledger, State = #state{db = DB, default = DefaultCF}) ->

--- a/src/bn_pending_txns.erl
+++ b/src/bn_pending_txns.erl
@@ -85,7 +85,12 @@ follower_height(#state{db = DB, default = DefaultCF}) ->
         {error, _} = Error -> ?jsonrpc_error(Error)
     end.
 
-load_chain(_Chain, State = #state{}) ->
+load_chain(Chain, State = #state{db = DB, default = CF}) ->
+    {ok, Height} = blockchain:height(Chain),
+    case bn_db:get_follower_height(DB, CF) of
+        {ok, 0} -> bn_db:put_follower_height(DB, CF, Height);
+        _ -> ok
+    end,
     Submitted = submit_pending_txns(State),
     lager:info("Submitted ~p pending transactions", [Submitted]),
     {ok, State}.


### PR DESCRIPTION
So this patch did fix a node after loading a snapshot onto it. But I still don't fully understand it tbh. I suppose the idea is that if the chain is moving, we just need to ensure that the modules which implement `blockchain_follower` behavior also correctly handle `load_chain` event and continue to move forward.