### PR TITLE
Update runner image to alpine 3.17 to match erlang image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 REBAR=./rebar3
 BUILDER_IMAGE=erlang:24-alpine
-RUNNER_IMAGE=alpine:3.16
+RUNNER_IMAGE=alpine:3.17
 APP_VERSION=$$(git tag --points-at HEAD)
 
 OS_NAME=$(shell uname -s)


### PR DESCRIPTION
Apparently `erlang:24-alpine` now uses `alpline:3.17` as a base layer (as of 7 days ago) which broke the runner container in our latest build.

This is a temporary fix but the real fix is likely to set a specific Erlang container version like `erlang:24.3.4.7-alpine`